### PR TITLE
clarify criteria concerning size/output value

### DIFF
--- a/report-03/criteria.md
+++ b/report-03/criteria.md
@@ -98,7 +98,7 @@ Each sub-category of privacy, such as "Receiving address management," is broken 
                     </li>
                     <li>Quality:
                         <ol type="a">
-                            <li>Does the wallet avoid creating recurring transactions of a known size or to a known address? (0.518%)</li>
+                            <li>Does the wallet avoid creating recurring transactions without outputs of a known value or to a known address? (0.518%)</li>
                         </ol>
                     </li>
                 </ol>

--- a/report-03/criteria.md
+++ b/report-03/criteria.md
@@ -98,7 +98,7 @@ Each sub-category of privacy, such as "Receiving address management," is broken 
                     </li>
                     <li>Quality:
                         <ol type="a">
-                            <li>Does the wallet avoid creating recurring transactions without outputs of a known value or to a known address? (0.518%)</li>
+                            <li>Does the wallet avoid creating recurring transactions with outputs of a known value or to a known address? (0.518%)</li>
                         </ol>
                     </li>
                 </ol>


### PR DESCRIPTION
“size” is ambiguous and could refer to the size of the transaction in
bytes, or the size of some portion of the transaction, as opposed to
the value of one or more outputs.
